### PR TITLE
Only send new data points to merge on indicator-service

### DIFF
--- a/app/schemas/resource.py
+++ b/app/schemas/resource.py
@@ -37,7 +37,3 @@ class ResourceDelete(BaseModel):
     id: str
     deleted: bool
 
-
-class ResourceData(BaseModel):
-    resource_id: PyObjectId
-    data: List[DataPoint]


### PR DESCRIPTION
### Resource2Indicator Data Sending
- Instead of sending a chunk with the smallest time-window that includes all the changed points, send only the changed points
- The main goal is to create a highly efficient way of solving data merge conflicts with a data-centric approach
- Indicator Service will easily merge this data with the indicator while guarantee that only the newest version of each data point is visible to the user 