### PR TITLE
Add wrapper auto-retry system and recovery improvements

### DIFF
--- a/app/prompt_templates/wrapper_runtime_retry.j2
+++ b/app/prompt_templates/wrapper_runtime_retry.j2
@@ -1,0 +1,28 @@
+The generated Python wrapper crashed at runtime with the error below.
+
+Fix the code and return the COMPLETE corrected Python file.
+
+CRITICAL RULES:
+- Return full code only, no explanations.
+- Keep existing wrapper structure, class name (ATTWrapper), and behavior.
+- Fix the specific runtime error shown in the traceback.
+- Do not introduce new bugs or change working logic unnecessarily.
+- Do not leave PLACEHOLDER or standalone ... in method bodies.
+- Ensure all datetime comparisons use consistent timezone handling (all naive or all aware).
+- Ensure all HTTP requests pass self.headers when authentication is configured.
+
+{% if original_prompt %}
+ORIGINAL GENERATION PROMPT (for context on what this wrapper should do):
+{{ original_prompt }}
+
+{% endif %}
+CRASHED WRAPPER CODE:
+{{ generated_code }}
+
+RUNTIME ERROR LOG (stderr):
+{{ error_log }}
+
+{% if stdout_log %}
+STDOUT LOG (last output before crash):
+{{ stdout_log }}
+{% endif %}

--- a/app/schemas/wrapper.py
+++ b/app/schemas/wrapper.py
@@ -16,6 +16,7 @@ class WrapperStatus(str, Enum):
     GENERATING = "generating"
     CREATING_RESOURCE = "creating_resource"
     EXECUTING = "executing"
+    RETRYING = "retrying"
     STOPPED = "stopped"
     COMPLETED = "completed"
     ERROR = "error"
@@ -126,6 +127,10 @@ class GeneratedWrapper(BaseModel):
     )
     low_water_mark: Optional[datetime] = Field(
         None, description="Oldest data point timestamp ever sent"
+    )
+
+    retry_count: int = Field(
+        default=0, description="Number of auto-retry attempts after runtime crash"
     )
 
     execution_result: Optional["WrapperExecutionResult"] = None

--- a/app/services/process_wrapper_monitor.py
+++ b/app/services/process_wrapper_monitor.py
@@ -182,7 +182,11 @@ class ProcessWrapperMonitor(WrapperMonitor):
             wrapper_doc = await db.generated_wrappers.find_one(
                 {"wrapper_id": wrapper_id}
             )
-            if wrapper_doc and wrapper_doc.get("status") in ["executing", "generating"]:
+            if wrapper_doc and wrapper_doc.get("status") in [
+                "executing",
+                "generating",
+                "retrying",
+            ]:
                 await db.generated_wrappers.update_one(
                     {"wrapper_id": wrapper_id},
                     {

--- a/app/services/prompt_manager.py
+++ b/app/services/prompt_manager.py
@@ -57,6 +57,22 @@ class PromptManager:
             linting_errors=linting_errors,
         )
 
+    def generate_runtime_retry_prompt(
+        self,
+        generated_code: str,
+        error_log: str,
+        original_prompt: str = None,
+        stdout_log: str = None,
+    ) -> str:
+        """Generate retry prompt for wrapper regeneration after runtime crash"""
+        template = self.env.get_template("wrapper_runtime_retry.j2")
+        return template.render(
+            generated_code=generated_code,
+            error_log=error_log,
+            original_prompt=original_prompt,
+            stdout_log=stdout_log,
+        )
+
     def _get_source_specific_instructions(
         self, source_type: str, periodicity: str
     ) -> str:

--- a/app/services/wrapper_process_manager.py
+++ b/app/services/wrapper_process_manager.py
@@ -188,19 +188,18 @@ class WrapperProcessManager:
                     # Append exit information to log files (never delete logs!)
                     await self._append_exit_info_to_logs(wrapper_id, exit_code)
 
-                    await db.generated_wrappers.update_one(
-                        {"wrapper_id": wrapper_id},
-                        {
-                            "$set": {
-                                "status": WrapperStatus.COMPLETED
-                                if exit_code == 0
-                                else WrapperStatus.ERROR
+                    if exit_code == 0:
+                        await db.generated_wrappers.update_one(
+                            {"wrapper_id": wrapper_id},
+                            {
+                                "$set": {"status": WrapperStatus.COMPLETED},
+                                "$push": {
+                                    "execution_log": f"Process completed at {datetime.utcnow()} with exit code 0"
+                                },
                             },
-                            "$push": {
-                                "execution_log": f"Process terminated at {datetime.utcnow()} with exit code {exit_code}"
-                            },
-                        },
-                    )
+                        )
+                    else:
+                        await self._handle_crashed_wrapper(wrapper_id, exit_code)
 
                 else:
                     # Process is running, update health check
@@ -214,6 +213,65 @@ class WrapperProcessManager:
         # Clean up dead processes
         for wrapper_id in dead_processes:
             await self._cleanup_process(wrapper_id)
+
+    async def _handle_crashed_wrapper(self, wrapper_id: str, exit_code: int):
+        """Check if a crashed wrapper should be auto-retried or marked as error."""
+        max_retries = 3
+        try:
+            wrapper_doc = await db.generated_wrappers.find_one(
+                {"wrapper_id": wrapper_id}
+            )
+            retry_count = (wrapper_doc or {}).get("retry_count", 0)
+
+            if retry_count < max_retries:
+                logger.info(
+                    f"Wrapper {wrapper_id} crashed (exit {exit_code}), "
+                    f"scheduling auto-retry {retry_count + 1}/{max_retries}"
+                )
+                await db.generated_wrappers.update_one(
+                    {"wrapper_id": wrapper_id},
+                    {
+                        "$set": {"status": "retrying"},
+                        "$push": {
+                            "execution_log": f"Crash at {datetime.utcnow()} (exit {exit_code}), auto-retry scheduled"
+                        },
+                    },
+                )
+
+                # Lazy import to avoid circular dependency
+                from services.wrapper_service import wrapper_service
+
+                asyncio.create_task(wrapper_service.retry_failed_wrapper(wrapper_id))
+            else:
+                logger.warning(
+                    f"Wrapper {wrapper_id} crashed (exit {exit_code}), "
+                    f"retries exhausted ({max_retries}/{max_retries})"
+                )
+                await db.generated_wrappers.update_one(
+                    {"wrapper_id": wrapper_id},
+                    {
+                        "$set": {
+                            "status": WrapperStatus.ERROR,
+                            "error_message": f"Failed after {max_retries} auto-retry attempts (exit code {exit_code})",
+                        },
+                        "$push": {
+                            "execution_log": f"Process terminated at {datetime.utcnow()} with exit code {exit_code}, retries exhausted"
+                        },
+                    },
+                )
+        except (OperationFailure, ConnectionError) as e:
+            logger.error(
+                f"Error handling crashed wrapper {wrapper_id}: {e}", exc_info=True
+            )
+            await db.generated_wrappers.update_one(
+                {"wrapper_id": wrapper_id},
+                {
+                    "$set": {"status": WrapperStatus.ERROR},
+                    "$push": {
+                        "execution_log": f"Process terminated at {datetime.utcnow()} with exit code {exit_code}"
+                    },
+                },
+            )
 
     async def start_wrapper_process(
         self,

--- a/app/services/wrapper_service.py
+++ b/app/services/wrapper_service.py
@@ -324,7 +324,7 @@ class WrapperService:
 
             logger.info(f"Completed wrapper creation {wrapper_id}")
 
-        except (OperationFailure, ConnectionError, TimeoutError) as e:
+        except (OperationFailure, ConnectionError, TimeoutError, OSError) as e:
             logger.error(
                 f"Database/Connection error processing wrapper {wrapper_id}: {e}"
             )
@@ -495,18 +495,232 @@ class WrapperService:
             logger.error(f"Error checking if wrapper {wrapper_id} is executing: {e}")
             return False
 
+    async def retry_failed_wrapper(self, wrapper_id: str) -> bool:
+        """Retry a crashed wrapper by calling Gemini with error context.
+
+        Returns True if retry was dispatched successfully, False otherwise.
+        Max 3 retries per wrapper.
+        """
+        max_retries = 3
+        try:
+            wrapper_doc = await db.generated_wrappers.find_one(
+                {"wrapper_id": wrapper_id}
+            )
+            if not wrapper_doc:
+                logger.error(f"Retry: wrapper {wrapper_id} not found")
+                return False
+
+            wrapper = GeneratedWrapper(**wrapper_doc)
+            current_retry = wrapper.retry_count
+
+            if current_retry >= max_retries:
+                logger.warning(
+                    f"Retry: wrapper {wrapper_id} exhausted {max_retries} retries"
+                )
+                await self._update_wrapper_status(
+                    wrapper_id,
+                    WrapperStatus.ERROR,
+                    error_message=f"Failed after {max_retries} auto-retry attempts",
+                )
+                return False
+
+            await self._update_wrapper_status(wrapper_id, WrapperStatus.RETRYING)
+
+            # Read original prompt from generation trace
+            original_prompt = None
+            trace_path = f"/app/prompts/{wrapper_id}/generation_trace.json"
+            try:
+                with open(trace_path, "r", encoding="utf-8") as f:
+                    trace_data = json.load(f)
+                    original_prompt = trace_data.get("initial_prompt")
+            except (FileNotFoundError, json.JSONDecodeError, IOError) as e:
+                logger.warning(
+                    f"Retry: could not read generation trace for {wrapper_id}: {e}"
+                )
+
+            # Read crashed code
+            wrapper_file_path = f"/app/generated_wrappers/{wrapper_id}.py"
+            try:
+                with open(wrapper_file_path, "r", encoding="utf-8") as f:
+                    generated_code = f.read()
+            except (FileNotFoundError, IOError) as e:
+                logger.error(
+                    f"Retry: could not read wrapper file for {wrapper_id}: {e}"
+                )
+                await self._update_wrapper_status(
+                    wrapper_id,
+                    WrapperStatus.ERROR,
+                    error_message=f"Retry failed: wrapper file not found",
+                )
+                return False
+
+            # Read error logs
+            error_log = ""
+            stderr_path = f"/app/wrapper_logs/{wrapper_id}_stderr.log"
+            try:
+                with open(stderr_path, "r", encoding="utf-8") as f:
+                    error_log = f.read()
+            except (FileNotFoundError, IOError):
+                pass
+
+            stdout_log = ""
+            stdout_path = f"/app/wrapper_logs/{wrapper_id}_stdout.log"
+            try:
+                with open(stdout_path, "r", encoding="utf-8") as f:
+                    lines = f.readlines()
+                    stdout_log = "".join(lines[-20:]) if lines else ""
+            except (FileNotFoundError, IOError):
+                pass
+
+            # Build retry prompt
+            retry_prompt = self.generator.prompt_manager.generate_runtime_retry_prompt(
+                generated_code=generated_code,
+                error_log=error_log or "No stderr captured",
+                original_prompt=original_prompt,
+                stdout_log=stdout_log or None,
+            )
+
+            # Call Gemini — use tool-calling for API wrappers
+            logger.info(
+                f"Retry {current_retry + 1}/{max_retries}: calling Gemini for wrapper {wrapper_id}"
+            )
+
+            auth_config = {}
+            if wrapper.source_type == SourceType.API:
+                auth_config = self.generator._build_api_auth_config(
+                    wrapper.source_config
+                )
+                fixed_code = await self.generator._call_model_with_tools(
+                    prompt=retry_prompt,
+                    auth_config=auth_config,
+                    max_tool_calls=10,
+                    max_chars=2500,
+                    wrapper_id=wrapper_id,
+                )
+            else:
+                fixed_code = await self.generator._call_model(retry_prompt)
+
+            fixed_code = self.generator._clean_code_response(fixed_code)
+
+            # Lint the fixed code
+            lint_error = self.generator._validate_generated_code(fixed_code)
+            if lint_error:
+                lint_retry_prompt = (
+                    self.generator.prompt_manager.generate_wrapper_lint_retry_prompt(
+                        generated_code=fixed_code,
+                        linting_errors=lint_error,
+                    )
+                )
+                lint_retry_response = await self.generator._call_model(
+                    lint_retry_prompt
+                )
+                fixed_code = self.generator._clean_code_response(lint_retry_response)
+
+                final_lint = self.generator._validate_generated_code(fixed_code)
+                if final_lint:
+                    logger.error(
+                        f"Retry: lint failed after retry for {wrapper_id}: {final_lint}"
+                    )
+                    await self._update_wrapper_status(
+                        wrapper_id,
+                        WrapperStatus.ERROR,
+                        error_message=f"Auto-retry {current_retry + 1} failed: lint errors after fix",
+                    )
+                    await db.generated_wrappers.update_one(
+                        {"wrapper_id": wrapper_id},
+                        {"$set": {"retry_count": current_retry + 1}},
+                    )
+                    return False
+
+            # Save fixed code
+            self.generator.save_wrapper(fixed_code, wrapper_id)
+
+            # Save retry trace
+            self.generator.debug_logger.log_generation_trace(
+                wrapper_id,
+                {
+                    "type": "runtime_retry",
+                    "retry_number": current_retry + 1,
+                    "prompt": retry_prompt,
+                    "fixed_code_length": len(fixed_code),
+                    "error_log_length": len(error_log),
+                },
+            )
+
+            # Update DB: increment retry_count, set status back to executing, store new code
+            await db.generated_wrappers.update_one(
+                {"wrapper_id": wrapper_id},
+                {
+                    "$set": {
+                        "retry_count": current_retry + 1,
+                        "generated_code": fixed_code,
+                        "status": WrapperStatus.EXECUTING.value,
+                        "updated_at": datetime.utcnow(),
+                        "error_message": None,
+                    },
+                    "$push": {
+                        "execution_log": f"Auto-retry {current_retry + 1} at {datetime.utcnow()}"
+                    },
+                },
+            )
+
+            # Restart execution
+            execution_result = await self._runner.execute_wrapper(wrapper)
+
+            if not execution_result.success:
+                logger.error(
+                    f"Retry: failed to restart wrapper {wrapper_id}: {execution_result.message}"
+                )
+                await self._update_wrapper_status(
+                    wrapper_id,
+                    WrapperStatus.ERROR,
+                    error_message=f"Auto-retry {current_retry + 1}: process start failed",
+                )
+                return False
+
+            logger.info(
+                f"Retry {current_retry + 1}/{max_retries}: wrapper {wrapper_id} restarted successfully"
+            )
+            return True
+
+        except Exception as e:
+            logger.error(
+                f"Retry: unexpected error for wrapper {wrapper_id}: {e}",
+                exc_info=True,
+            )
+            await self._update_wrapper_status(
+                wrapper_id,
+                WrapperStatus.ERROR,
+                error_message=f"Auto-retry failed: {str(e)}",
+            )
+            return False
+
     async def restart_executing_wrappers(self):
         """Restart continuous wrappers that were executing before service restart.
 
+        Also re-triggers retries for wrappers stuck in 'retrying' status
+        (the asyncio task was lost when the service restarted).
         Skips wrappers whose processes were already adopted from OS by the process manager.
         """
         try:
+            # Pick up wrappers in 'retrying' that lost their retry task on restart
+            retrying_wrappers = await db.generated_wrappers.find(
+                {"status": "retrying"}
+            ).to_list(length=None)
+            for wrapper_doc in retrying_wrappers:
+                wid = wrapper_doc.get("wrapper_id", "unknown")
+                logger.info(f"Re-scheduling interrupted retry for wrapper {wid}")
+                asyncio.create_task(self.retry_failed_wrapper(wid))
+
             executing_wrappers = await db.generated_wrappers.find(
                 {"status": "executing"}
             ).to_list(length=None)
 
+            if not executing_wrappers and not retrying_wrappers:
+                logger.info("No executing/retrying wrappers found to restart")
+                return
+
             if not executing_wrappers:
-                logger.info("No executing wrappers found to restart")
                 return
 
             restarted_count = 0

--- a/app/wrapper_runtime/shared/utils.py
+++ b/app/wrapper_runtime/shared/utils.py
@@ -738,9 +738,6 @@ class ContinuousExecutor:
                 print(f"Wrapper {self.wrapper_id}: Stopping execution")
                 break
             except (
-                ValueError,
-                KeyError,
-                TypeError,
                 ConnectionError,
                 TimeoutError,
                 OSError,


### PR DESCRIPTION
## Summary
- Add auto-retry system (up to 3 attempts) for crashed wrappers using Gemini regeneration with error context
- Improve wrapper recovery on service restart by re-scheduling interrupted retries
- Narrow exception handling in continuous executor so runtime crashes trigger the retry pipeline instead of being silently swallowed

## Test plan
- [x] E2E test: create indicator → generate wrapper with INE API → verify data pipeline end-to-end (14 data points stored)
- [x] Wrapper process confirmed alive and healthy after 70+ seconds
- [ ] Verify auto-retry triggers on wrapper crash (simulate by injecting a transient API error)
- [ ] Verify retries exhaust after 3 attempts and wrapper is marked as ERROR