### PR TITLE
fix gemini usage

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -19,7 +19,7 @@ class Settings(BaseSettings):
 
     # Wrapper Generation
     GEMINI_API_KEY: str = Field(..., env="GEMINI_API_KEY")
-    GEMINI_MODEL_NAME: str = Field(default="gemini-1.5-flash", env="GEMINI_MODEL_NAME")
+    GEMINI_MODEL_NAME: str = Field(default="gemini-flash-latest", env="GEMINI_MODEL_NAME")
     DATA_RABBITMQ_URL: str = Field(
         default="amqp://user:password@data-mq:5672/", env="DATA_RABBITMQ_URL"
     )

--- a/app/services/wrapper_generator.py
+++ b/app/services/wrapper_generator.py
@@ -302,11 +302,19 @@ class WrapperGenerator:
         }
 
         while True:
-            response = await self.client.aio.models.generate_content(
-                model=self.model_name,
-                contents=contents,
-                config=config,
-            )
+            try:
+                response = await asyncio.wait_for(
+                    self.client.aio.models.generate_content(
+                        model=self.model_name,
+                        contents=contents,
+                        config=config,
+                    ),
+                    timeout=self._GEMINI_CALL_TIMEOUT_S,
+                )
+            except asyncio.TimeoutError as exc:
+                raise ValueError(
+                    f"Gemini call timed out after {self._GEMINI_CALL_TIMEOUT_S}s"
+                ) from exc
 
             function_calls = response.function_calls or []
 
@@ -372,11 +380,19 @@ class WrapperGenerator:
                         ],
                     )
                 )
-                final_response = await self.client.aio.models.generate_content(
-                    model=self.model_name,
-                    contents=contents,
-                    config=types.GenerateContentConfig(),
-                )
+                try:
+                    final_response = await asyncio.wait_for(
+                        self.client.aio.models.generate_content(
+                            model=self.model_name,
+                            contents=contents,
+                            config=types.GenerateContentConfig(),
+                        ),
+                        timeout=self._GEMINI_CALL_TIMEOUT_S,
+                    )
+                except asyncio.TimeoutError as exc:
+                    raise ValueError(
+                        f"Gemini call timed out after {self._GEMINI_CALL_TIMEOUT_S}s"
+                    ) from exc
                 trace["final_response"] = (final_response.text or "").strip()
                 trace["turns"].append(
                     {

--- a/app/services/wrapper_generator.py
+++ b/app/services/wrapper_generator.py
@@ -250,11 +250,21 @@ class WrapperGenerator:
 
         return None
 
+    _GEMINI_CALL_TIMEOUT_S = 300
+
     async def _call_model(self, prompt: str) -> str:
-        response = await self.client.aio.models.generate_content(
-            model=self.model_name,
-            contents=prompt,
-        )
+        try:
+            response = await asyncio.wait_for(
+                self.client.aio.models.generate_content(
+                    model=self.model_name,
+                    contents=prompt,
+                ),
+                timeout=self._GEMINI_CALL_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError as exc:
+            raise ValueError(
+                f"Gemini call timed out after {self._GEMINI_CALL_TIMEOUT_S}s"
+            ) from exc
         return (response.text or "").strip()
 
     async def _call_model_with_tools(

--- a/app/services/wrapper_service.py
+++ b/app/services/wrapper_service.py
@@ -706,13 +706,15 @@ class WrapperService:
             # Fail wrappers orphaned mid-generation by a service restart.
             # Their consumer task was killed — requeueing isn't safe because
             # partial state (resource row, file) already exists.
+            error_timestamp = datetime.utcnow()
             orphaned = await db.generated_wrappers.update_many(
-                {"status": {"$in": ["pending", "generating"]}},
+                {"status": WrapperStatus.GENERATING.value},
                 {
                     "$set": {
                         "status": WrapperStatus.ERROR.value,
                         "error_message": "Wrapper generation interrupted by service restart",
-                        "updated_at": datetime.utcnow(),
+                        "updated_at": error_timestamp,
+                        "completed_at": error_timestamp,
                     }
                 },
             )

--- a/app/services/wrapper_service.py
+++ b/app/services/wrapper_service.py
@@ -703,6 +703,24 @@ class WrapperService:
         Skips wrappers whose processes were already adopted from OS by the process manager.
         """
         try:
+            # Fail wrappers orphaned mid-generation by a service restart.
+            # Their consumer task was killed — requeueing isn't safe because
+            # partial state (resource row, file) already exists.
+            orphaned = await db.generated_wrappers.update_many(
+                {"status": {"$in": ["pending", "generating"]}},
+                {
+                    "$set": {
+                        "status": WrapperStatus.ERROR.value,
+                        "error_message": "Wrapper generation interrupted by service restart",
+                        "updated_at": datetime.utcnow(),
+                    }
+                },
+            )
+            if orphaned.modified_count:
+                logger.info(
+                    f"Marked {orphaned.modified_count} orphaned wrapper(s) as ERROR after restart"
+                )
+
             # Pick up wrappers in 'retrying' that lost their retry task on restart
             retrying_wrappers = await db.generated_wrappers.find(
                 {"status": "retrying"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - MONGO_URI=mongodb://resource-mongo:27017/resources
       - ORIGINS=${ORIGINS:-localhost}
       - GEMINI_API_KEY=${GEMINI_API_KEY}
-      - GEMINI_MODEL_NAME=${GEMINI_MODEL_NAME:-gemini-1.5-flash}
+      - GEMINI_MODEL_NAME=${GEMINI_MODEL_NAME:-gemini-flash-latest}
       - RABBITMQ_URL=amqp://user:password@services-mq:5672/
       - DATA_RABBITMQ_URL=amqp://user:password@data-mq:5672/
     depends_on:


### PR DESCRIPTION
This pull request introduces improvements to the wrapper generation service, focusing on reliability during service restarts and updating the Gemini model defaults. The most significant changes include updating the default Gemini model to the latest version, ensuring orphaned wrapper generations are properly marked as errors after a service restart, and adding a timeout to Gemini API calls to prevent indefinite hangs.

**Reliability and Error Handling Improvements:**

* The `restart_executing_wrappers` method in `wrapper_service.py` now marks any wrappers left in a "pending" or "generating" state as `ERROR` with an appropriate message if the service is restarted mid-generation. This prevents inconsistent state and clarifies why a wrapper failed.
* The Gemini API call in `wrapper_generator.py` is now wrapped in a 300-second timeout. If the call takes too long, it raises a clear error, preventing the service from hanging indefinitely on slow or unresponsive model calls.

**Configuration Updates:**

* The default Gemini model has been updated from `"gemini-1.5-flash"` to `"gemini-flash-latest"` in both `config.py` and `docker-compose.yml`, ensuring the service uses the most current model by default. [[1]](diffhunk://#diff-84f1a9419471e289c6b6e2b0209b329e20df6cef81d1f7f0a193ddc2fc6ad69dL22-R22) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L12-R12)