### PR TITLE
fix the dying api wrappers

### DIFF
--- a/app/services/process_wrapper_runner.py
+++ b/app/services/process_wrapper_runner.py
@@ -47,6 +47,7 @@ class ProcessWrapperRunner(WrapperRunner):
                 resume_phase=resume_phase,
                 resume_high_water_mark=resume_high_water_mark,
                 resume_low_water_mark=resume_low_water_mark,
+                continuous=wrapper.source_type == SourceType.API,
             )
 
             if success:

--- a/app/services/wrapper_process_manager.py
+++ b/app/services/wrapper_process_manager.py
@@ -17,7 +17,7 @@ WRAPPER_DIR = "/app/generated_wrappers"
 
 
 class WrapperProcess:
-    def __init__(self, wrapper_id: str, process: subprocess.Popen, temp_file_path: str):
+    def __init__(self, wrapper_id: str, process: subprocess.Popen, temp_file_path: str, continuous: bool = False):
         self.wrapper_id = wrapper_id
         self.process = process
         self.temp_file_path = temp_file_path
@@ -26,6 +26,13 @@ class WrapperProcess:
         # Whether this wrapper is holding a concurrency slot from the manager's
         # semaphore. Set after a successful acquire in start_wrapper_process.
         self.holds_slot = False
+        # API wrappers run a polling loop forever; one-shot file wrappers
+        # (CSV/XLSX) finish quickly. The execution-timeout health check only
+        # applies to one-shot wrappers — without this distinction, every API
+        # wrapper got killed after WRAPPER_EXECUTION_TIMEOUT_SECONDS and
+        # never resumed, so its resource would only ever carry the data from
+        # the initial historical fetch.
+        self.continuous = continuous
 
 
 class _AdoptedProcess:
@@ -109,7 +116,11 @@ class WrapperProcessManager:
 
                     wrapper_file = f"{WRAPPER_DIR}/{wrapper_id}.py"
                     process = _AdoptedProcess(pid)
-                    wp = WrapperProcess(wrapper_id, process, wrapper_file)
+                    # Adopted wrapper subprocesses are by definition long-lived
+                    # (only API wrappers survive a service restart — file
+                    # wrappers complete and exit). Mark continuous so the
+                    # execution-timeout watchdog doesn't kill them.
+                    wp = WrapperProcess(wrapper_id, process, wrapper_file, continuous=True)
                     # Adopted processes already exist; they don't consume a
                     # new-spawn slot. holds_slot stays False so cleanup won't
                     # release an uncounted slot.
@@ -219,9 +230,12 @@ class WrapperProcessManager:
 
                 else:
                     # Process is running. Enforce execution timeout if set.
+                    # Skip for continuous (API) wrappers — they're supposed
+                    # to run forever; killing them mid-poll-cycle was the
+                    # bug that left indicators stuck on initial-load data.
                     now = datetime.utcnow()
                     wrapper_process.last_health_check = now
-                    if self._execution_timeout is not None:
+                    if self._execution_timeout is not None and not wrapper_process.continuous:
                         runtime = (now - wrapper_process.started_at).total_seconds()
                         if runtime > self._execution_timeout:
                             logger.warning(
@@ -337,6 +351,7 @@ class WrapperProcessManager:
         resume_phase: Optional[str] = None,
         resume_high_water_mark: Optional[str] = None,
         resume_low_water_mark: Optional[str] = None,
+        continuous: bool = False,
     ) -> bool:
         """Start a wrapper in a separate process.
 
@@ -403,7 +418,7 @@ class WrapperProcessManager:
             )
 
             # Store process info
-            wrapper_process = WrapperProcess(wrapper_id, process, wrapper_file_path)
+            wrapper_process = WrapperProcess(wrapper_id, process, wrapper_file_path, continuous=continuous)
             wrapper_process.holds_slot = True
             self.running_processes[wrapper_id] = wrapper_process
             # Slot ownership transferred to wrapper_process; do not release

--- a/app/wrapper_runtime/shared/utils.py
+++ b/app/wrapper_runtime/shared/utils.py
@@ -592,12 +592,13 @@ def get_interval_from_periodicity(periodicity: str) -> int:
         or "semana" in periodicity_lower
     ):
         return 3600 * 24 * 7
-    # Month: "monthly", "month", "mensal", "mês", "meses"
+    # Month: "monthly", "month", "mensal", "mês", "mes" (unaccented), "meses"
     elif (
         "monthly" in periodicity_lower
         or "month" in periodicity_lower
         or "mensal" in periodicity_lower
         or "mês" in periodicity_lower
+        or "mes" in periodicity_lower
         or "meses" in periodicity_lower
     ):
         return 3600 * 24 * 30

--- a/app/wrapper_runtime/shared/utils.py
+++ b/app/wrapper_runtime/shared/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import random
 import time
 from typing import Optional, Dict, Any, List, Callable, Awaitable
 from requests.models import Response
@@ -548,17 +549,21 @@ class MessageQueueSender:
 
 def get_interval_from_periodicity(periodicity: str) -> int:
     """
-    Convert periodicity string to seconds
+    Convert periodicity string to seconds.
 
-    Args:
-        periodicity: String like 'Daily', 'Hourly', 'Weekly', etc.
+    Recognises both English ("Daily", "Hourly", "Weekly", …) and Portuguese
+    ("Diário", "Horário", "Semanal", "Mensal", "Anual", …) labels because the
+    UI lets users type a free-text periodicity in their native language.
+    Unrecognised values fall back to daily.
 
-    Returns:
-        Number of seconds for the interval
+    Yearly-ish periodicities are intentionally clamped to one day so the
+    wrapper still picks up new API data within 24h instead of sleeping for
+    a full year.
     """
     periodicity_lower = periodicity.lower()
 
-    if "minute" in periodicity_lower:
+    # Minute (incl. Portuguese "minuto")
+    if "minute" in periodicity_lower or "minut" in periodicity_lower:
         if "5" in periodicity_lower:
             return 5 * 60
         elif "10" in periodicity_lower:
@@ -569,14 +574,43 @@ def get_interval_from_periodicity(periodicity: str) -> int:
             return 30 * 60
         else:
             return 60  # Default to 1 minute
-    elif "hour" in periodicity_lower:
+    # Hour: "hour", "hourly", "hora", "horário", "horária"
+    elif "hour" in periodicity_lower or "horár" in periodicity_lower or "hora" in periodicity_lower:
         return 3600
-    elif "daily" in periodicity_lower or "day" in periodicity_lower:
+    # Day: "daily", "day", "diário", "diária", "diariamente"
+    elif (
+        "daily" in periodicity_lower
+        or "day" in periodicity_lower
+        or "diár" in periodicity_lower
+        or "dia" in periodicity_lower
+    ):
         return 3600 * 24
-    elif "weekly" in periodicity_lower or "week" in periodicity_lower:
+    # Week: "weekly", "week", "semana", "semanal"
+    elif (
+        "weekly" in periodicity_lower
+        or "week" in periodicity_lower
+        or "semana" in periodicity_lower
+    ):
         return 3600 * 24 * 7
-    elif "monthly" in periodicity_lower or "month" in periodicity_lower:
+    # Month: "monthly", "month", "mensal", "mês", "meses"
+    elif (
+        "monthly" in periodicity_lower
+        or "month" in periodicity_lower
+        or "mensal" in periodicity_lower
+        or "mês" in periodicity_lower
+        or "meses" in periodicity_lower
+    ):
         return 3600 * 24 * 30
+    # Year: "yearly", "year", "anual", "anualmente", "ano". Clamp to 24h —
+    # an annual indicator polled once per year would never surface mid-year
+    # API updates.
+    elif (
+        "yearly" in periodicity_lower
+        or "year" in periodicity_lower
+        or "anual" in periodicity_lower
+        or "ano" in periodicity_lower
+    ):
+        return 3600 * 24
     else:
         # Default to daily if not recognized
         return 3600 * 24
@@ -669,6 +703,18 @@ class ContinuousExecutor:
             print(f"Wrapper {self.wrapper_id}: Continuous mode using run_once")
         print(f"Interval: {self.interval_seconds}s")
 
+        # First continuous sleep is jittered so a cohort of wrappers that
+        # entered continuous mode together (e.g. after a service restart or
+        # batch regeneration) spreads out over the polling window instead of
+        # waking in sync every interval and hammering APIs / data-collector.
+        # Subsequent sleeps are exactly `interval_seconds` from each
+        # wrapper's own previous wake, so the spread is preserved naturally.
+        # Range is [0.5, 1.0] × interval — never less than half the interval
+        # so a wrapper doesn't burn the API immediately, never more than the
+        # interval so the user sees at least one poll per `interval_seconds`
+        # window.
+        first_sleep = True
+
         while True:
             try:
                 if use_date_range:
@@ -730,10 +776,19 @@ class ContinuousExecutor:
                 else:
                     await run_once_func()
 
-                print(
-                    f"Wrapper {self.wrapper_id}: Waiting {self.interval_seconds}s until next execution..."
-                )
-                await asyncio.sleep(self.interval_seconds)
+                if first_sleep:
+                    sleep_for = self.interval_seconds * random.uniform(0.5, 1.0)
+                    first_sleep = False
+                    print(
+                        f"Wrapper {self.wrapper_id}: Waiting {sleep_for:.0f}s "
+                        f"(jittered first sleep) until next execution..."
+                    )
+                else:
+                    sleep_for = self.interval_seconds
+                    print(
+                        f"Wrapper {self.wrapper_id}: Waiting {self.interval_seconds}s until next execution..."
+                    )
+                await asyncio.sleep(sleep_for)
             except KeyboardInterrupt:
                 print(f"Wrapper {self.wrapper_id}: Stopping execution")
                 break


### PR DESCRIPTION
This pull request introduces several important improvements to the wrapper process management and runtime, focusing on correctly handling long-running API wrappers, improving periodicity parsing for internationalization, and reducing API load spikes by jittering poll intervals. The main changes are grouped below:

**Wrapper Process Management Improvements:**

* Added a `continuous` flag to the `WrapperProcess` class and its initialization in `wrapper_process_manager.py`, distinguishing between long-running API wrappers and one-shot file wrappers. This prevents API wrappers from being killed by the execution-timeout watchdog, fixing an issue where API wrappers would only ever load initial data. [[1]](diffhunk://#diff-ed9f42f5d58e614373a303556afbe8c0c76a15047afe8e2f5284f3960a2643e6L20-R20) [[2]](diffhunk://#diff-ed9f42f5d58e614373a303556afbe8c0c76a15047afe8e2f5284f3960a2643e6R29-R35) [[3]](diffhunk://#diff-6a17041fa8db53b9a1bb79ebed49d3625d2768eeca094cd8c15394a191d244d4R50) [[4]](diffhunk://#diff-ed9f42f5d58e614373a303556afbe8c0c76a15047afe8e2f5284f3960a2643e6L112-R123) [[5]](diffhunk://#diff-ed9f42f5d58e614373a303556afbe8c0c76a15047afe8e2f5284f3960a2643e6R233-R238) [[6]](diffhunk://#diff-ed9f42f5d58e614373a303556afbe8c0c76a15047afe8e2f5284f3960a2643e6R354) [[7]](diffhunk://#diff-ed9f42f5d58e614373a303556afbe8c0c76a15047afe8e2f5284f3960a2643e6L406-R421)

**Internationalization and Robustness in Periodicity Parsing:**

* Enhanced `get_interval_from_periodicity` in `utils.py` to recognize both English and Portuguese periodicity labels, improving support for user-inputted free-text periodicity. Yearly intervals are now clamped to 24 hours to ensure timely data updates. [[1]](diffhunk://#diff-5a04e23e98977e5343d388bc234241a1e6312f12f81b04fbe8294a642c95412dL551-R566) [[2]](diffhunk://#diff-5a04e23e98977e5343d388bc234241a1e6312f12f81b04fbe8294a642c95412dL572-R613)

**Load Distribution and API Protection:**

* Introduced jitter to the first sleep interval in `run_continuous` so that multiple wrappers starting together don't all poll at the same time, reducing the risk of API/data-collector overload after restarts or batch operations. [[1]](diffhunk://#diff-5a04e23e98977e5343d388bc234241a1e6312f12f81b04fbe8294a642c95412dR706-R717) [[2]](diffhunk://#diff-5a04e23e98977e5343d388bc234241a1e6312f12f81b04fbe8294a642c95412dR779-R791)

**Minor Code Improvements:**

* Added `import random` to `utils.py` to support the jitter logic.