### PR TITLE
fix resources

### DIFF
--- a/app/schemas/resource.py
+++ b/app/schemas/resource.py
@@ -28,6 +28,12 @@ class Resource(ResourceBase):
     id: PyObjectId
     startPeriod: Optional[datetime] = None
     endPeriod: Optional[datetime] = None
+    # Source type of the underlying wrapper ("API" | "CSV" | "XLSX"),
+    # denormalised into the response so the UI can classify resources by
+    # source without round-tripping to fetch every wrapper. `type` above is
+    # the resource category (e.g. "sustainability_indicator") and is not a
+    # reliable signal for API-vs-upload classification.
+    source_type: Optional[str] = None
 
     class Config:
         from_attributes = True

--- a/app/services/resource_service.py
+++ b/app/services/resource_service.py
@@ -16,6 +16,37 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+async def _attach_source_types(resources: List[dict]) -> List[dict]:
+    """Batch-fetch the wrappers for the given resources and stamp each
+    resource with the wrapper's `source_type` ("API" / "CSV" / "XLSX").
+
+    The resource document's own `type` field is the resource category
+    (e.g. "sustainability_indicator"), not its data source, so the UI
+    can't classify API vs upload from the resource alone.
+    """
+    if not resources:
+        return resources
+
+    wrapper_ids = {r.get("wrapper_id") for r in resources if r.get("wrapper_id")}
+    source_by_wrapper: dict = {}
+    if wrapper_ids:
+        try:
+            cursor = db.generated_wrappers.find(
+                {"wrapper_id": {"$in": list(wrapper_ids)}},
+                {"wrapper_id": 1, "source_type": 1, "_id": 0},
+            )
+            async for w in cursor:
+                source_by_wrapper[w["wrapper_id"]] = w.get("source_type")
+        except OperationFailure as e:
+            # Don't fail the resource list because the side-lookup broke —
+            # source_type stays null and the UI just treats it as unknown.
+            logger.warning(f"Could not load wrapper source_types: {e}")
+
+    for r in resources:
+        r["source_type"] = source_by_wrapper.get(r.get("wrapper_id"))
+    return resources
+
+
 async def get_all_resources(skip: int = 0, limit: int = 10) -> List[dict]:
     try:
         resources = (
@@ -24,7 +55,8 @@ async def get_all_resources(skip: int = 0, limit: int = 10) -> List[dict]:
             .limit(limit)
             .to_list(limit)
         )
-        return [serialize(resource) for resource in resources]
+        serialized = [serialize(resource) for resource in resources]
+        return await _attach_source_types(serialized)
     except OperationFailure as e:
         logger.error(f"Database operation failed in get_all_resources: {e}")
         raise
@@ -35,7 +67,11 @@ async def get_resource_by_id(resource_id: str) -> Optional[dict]:
         resource = await db.resources.find_one(
             {"_id": ObjectId(resource_id), "deleted": False}
         )
-        return serialize(resource) if resource else None
+        if not resource:
+            return None
+        serialized = serialize(resource)
+        await _attach_source_types([serialized])
+        return serialized
     except InvalidId as e:
         logger.error(f"Invalid resource ID format: {resource_id}")
         raise ValueError(f"Invalid resource ID: {resource_id}")


### PR DESCRIPTION
This pull request enhances how resource data is returned to the UI by including a new `source_type` field that indicates the underlying data source (such as "API", "CSV", or "XLSX"). This allows the UI to classify resources by their source without making additional database calls. The changes involve updating both the resource schema and the service layer to fetch and attach this information efficiently.

**Schema and API response improvements:**

* Added a new optional `source_type` field to the `Resource` schema in `resource.py`, allowing the API to return the data source type for each resource.

**Service layer enhancements:**

* Implemented the `_attach_source_types` helper in `resource_service.py` to batch-fetch wrapper source types for a list of resources and annotate each resource with its corresponding `source_type`. The function gracefully handles database errors by logging a warning and leaving the field as `None` if the lookup fails.
* Updated `get_all_resources` to use `_attach_source_types` so that all resources returned from this endpoint now include the `source_type` field.
* Updated `get_resource_by_id` to also use `_attach_source_types`, ensuring that single resource fetches include the `source_type` field.